### PR TITLE
🐛 fix(actual-api): correct service port configuration

### DIFF
--- a/kubernetes/apps/selfhosted/actual-budget/api/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/actual-budget/api/helmrelease.yaml
@@ -40,8 +40,6 @@ spec:
               pullPolicy: IfNotPresent
 
             env:
-              # API configuration
-              API_PORT: &port 3000
               # Connection to Actual Budget server
               ACTUAL_SERVER_URL: "http://actual-budget.selfhosted.svc.cluster.local:5006"
 
@@ -56,7 +54,7 @@ spec:
                 spec:
                   httpGet:
                     path: /health
-                    port: *port
+                    port: &port 5007
                   initialDelaySeconds: 30
                   periodSeconds: 30
                   timeoutSeconds: 10


### PR DESCRIPTION
- Fix port reference from 3000 to 5007 for health checks
- Remove unused API_PORT environment variable
- Align with actual service port configuration