### PR TITLE
🔧 chore(actual-api): disable health probes temporarily

### DIFF
--- a/kubernetes/apps/selfhosted/actual-budget/api/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/actual-budget/api/helmrelease.yaml
@@ -49,7 +49,7 @@ spec:
 
             probes:
               liveness:
-                enabled: true
+                enabled: false
                 custom: true
                 spec:
                   httpGet:
@@ -60,7 +60,7 @@ spec:
                   timeoutSeconds: 10
                   failureThreshold: 3
               readiness:
-                enabled: true
+                enabled: false
                 custom: true
                 spec:
                   httpGet:
@@ -71,7 +71,7 @@ spec:
                   timeoutSeconds: 5
                   failureThreshold: 3
               startup:
-                enabled: true
+                enabled: false
                 custom: true
                 spec:
                   httpGet:


### PR DESCRIPTION
- Disable liveness, readiness, and startup probes
- Allow service to start without health check dependencies
- Temporary measure during initial deployment phase