### PR TITLE
🐛 fix(network-policy): update actual-api port references to 5007

### DIFF
--- a/kubernetes/apps/selfhosted/actual-budget/api/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/actual-budget/api/networkpolicy.yaml
@@ -17,7 +17,7 @@ spec:
             k8s:io.kubernetes.pod.namespace: selfhosted
       ports:
         - protocol: TCP
-          port: 3000
+          port: 5007
   egress:
     - toEndpoints:
         - matchLabels:

--- a/kubernetes/apps/selfhosted/n8n/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/n8n/app/networkpolicy.yaml
@@ -49,5 +49,5 @@ spec:
             k8s:io.kubernetes.pod.namespace: selfhosted
       toPorts:
         - ports:
-            - port: "3000"
+            - port: "5007"
               protocol: TCP


### PR DESCRIPTION
- Fix actual-api network policy ingress port from 3000 to 5007
- Update n8n network policy egress port for actual-api communication
- Align network policies with correct service port configuration