### PR TITLE
✨ feat: add Gateway API CRDs support

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -59,6 +59,16 @@
       },
     },
     {
+      description: "Gateway API CRDs Group",
+      groupName: "gateway-api-crds",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/gateway-api-crds/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+      minimumGroupSize: 2,
+    },
+    {
       description: "Rook-Ceph Group",
       groupName: "Rook-Ceph",
       matchDatasources: ["docker"],
@@ -87,6 +97,7 @@
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },
+      minimumGroupSize: 2,
     },
   ],
 }

--- a/kubernetes/apps/kube-system/gateway-api-crds/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/gateway-api-crds/app/helmrelease.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: gateway-api-crds
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.3.0
+  url: oci://ghcr.io/wiremind/wiremind-helm-charts/gateway-api-crds
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cilium
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gateway-api-crds
+  interval: 30m

--- a/kubernetes/apps/kube-system/gateway-api-crds/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/gateway-api-crds/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/gateway-api-crds/ks.yaml
+++ b/kubernetes/apps/kube-system/gateway-api-crds/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname gateway-api-crds
+  namespace: &namespace kube-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/gateway-api-crds/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 5m
+  wait: false

--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: kube-system
 resources:
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml
+  - ./gateway-api-crds/ks.yaml
   - ./metrics-server/ks.yaml
 components:
   - ../../components/namespace


### PR DESCRIPTION
- Add Gateway API CRDs HelmRelease and Kustomization
- Enable Gateway API infrastructure components
- Update kube-system kustomization to include gateway-api-crds
- Add renovate group for gateway-api-crds updates
- Configure minimumGroupSize for renovate groups