### PR TITLE
🔧 chore: update network policies for ghostfolio and n8n

### DIFF
--- a/kubernetes/apps/selfhosted/ghostfolio/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/ghostfolio/app/networkpolicy.yaml
@@ -8,11 +8,23 @@ spec:
   endpointSelector:
     matchLabels:
       app.kubernetes.io/name: ghostfolio
+      k8s:io.kubernetes.pod.namespace: selfhosted
+  ingress:
+    # n8n
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: n8n
+            k8s:io.kubernetes.pod.namespace: selfhosted
+      toPorts:
+        - ports:
+            - port: "3333"
+              protocol: TCP
   egress:
     # Redis
     - toEndpoints:
         - matchLabels:
             app.kubernetes.io/name: ghostfolio-redis
+            k8s:io.kubernetes.pod.namespace: selfhosted
       toPorts:
         - ports:
             - port: "6379"

--- a/kubernetes/apps/selfhosted/ghostfolio/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/ghostfolio/app/networkpolicy.yaml
@@ -9,16 +9,6 @@ spec:
     matchLabels:
       app.kubernetes.io/name: ghostfolio
       k8s:io.kubernetes.pod.namespace: selfhosted
-  ingress:
-    # n8n
-    - fromEndpoints:
-        - matchLabels:
-            app.kubernetes.io/name: n8n
-            k8s:io.kubernetes.pod.namespace: selfhosted
-      toPorts:
-        - ports:
-            - port: "3333"
-              protocol: TCP
   egress:
     # Redis
     - toEndpoints:

--- a/kubernetes/apps/selfhosted/n8n/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/n8n/app/networkpolicy.yaml
@@ -51,3 +51,13 @@ spec:
         - ports:
             - port: "5007"
               protocol: TCP
+
+    # n8n
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: n8n
+            k8s:io.kubernetes.pod.namespace: selfhosted
+      toPorts:
+        - ports:
+            - port: "3333"
+              protocol: TCP


### PR DESCRIPTION
- Add namespace labels to endpoint selectors for better isolation
- Enable n8n to ghostfolio communication on port 3333
- Improve network policy specificity with k8s namespace labels