### PR TITLE
🔧 chore: allow n8n to ghostfolio network communication

### DIFF
--- a/kubernetes/apps/selfhosted/ghostfolio/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/ghostfolio/app/networkpolicy.yaml
@@ -13,7 +13,18 @@ spec:
     - toEndpoints:
         - matchLabels:
             app.kubernetes.io/name: ghostfolio-redis
+            k8s:io.kubernetes.pod.namespace: selfhosted
       toPorts:
         - ports:
             - port: "6379"
+              protocol: TCP
+  ingress:
+    # n8n
+    - fromEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: n8n
+            k8s:io.kubernetes.pod.namespace: selfhosted
+      toPorts:
+        - ports:
+            - port: "3333"
               protocol: TCP

--- a/kubernetes/apps/selfhosted/n8n/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/n8n/app/networkpolicy.yaml
@@ -51,3 +51,13 @@ spec:
         - ports:
             - port: "5007"
               protocol: TCP
+
+    # ghostfolio
+    - toEndpoints:
+        - matchLabels:
+            app.kubernetes.io/name: ghostfolio
+            k8s:io.kubernetes.pod.namespace: selfhosted
+      toPorts:
+        - ports:
+            - port: "3333"
+              protocol: TCP


### PR DESCRIPTION
- Add ingress rule to allow n8n access to ghostfolio on port 3333
- Add egress rule in n8n network policy for outbound ghostfolio connection